### PR TITLE
Try to optimistically confirm account head when doing backlog population

### DIFF
--- a/nano/node/election_scheduler.cpp
+++ b/nano/node/election_scheduler.cpp
@@ -21,7 +21,7 @@ void nano::election_scheduler::manual (std::shared_ptr<nano::block> const & bloc
 	notify ();
 }
 
-bool nano::election_scheduler::activate (nano::account const & account_a, nano::transaction const & transaction)
+bool nano::election_scheduler::activate (nano::account const & account_a, nano::transaction const & transaction, bool activate_account_head)
 {
 	bool result = false;
 	debug_assert (!account_a.is_zero ());
@@ -41,6 +41,16 @@ bool nano::election_scheduler::activate (nano::account const & account_a, nano::
 				nano::lock_guard<nano::mutex> lock{ mutex };
 				result = priority.push (account_info.modified, block);
 				notify ();
+			}
+			if (activate_account_head && account_info.head != hash)
+			{
+				auto block = node.store.block.get (transaction, account_info.head);
+				debug_assert (block != nullptr);
+				{
+					nano::lock_guard<nano::mutex> lock{ mutex };
+					result = priority.push (account_info.modified, block);
+					notify ();
+				}
 			}
 		}
 	}

--- a/nano/node/election_scheduler.hpp
+++ b/nano/node/election_scheduler.hpp
@@ -24,7 +24,7 @@ public:
 	// Call action with confirmed block, may be different than what we started with
 	void manual (std::shared_ptr<nano::block> const &, boost::optional<nano::uint128_t> const & = boost::none, nano::election_behavior = nano::election_behavior::normal, std::function<void (std::shared_ptr<nano::block> const &)> const & = nullptr);
 	// Activates the first unconfirmed block of \p account_a
-	bool activate (nano::account const &, nano::transaction const &);
+	bool activate (nano::account const &, nano::transaction const &, bool activate_account_head = false);
 	void stop ();
 	// Blocks until no more elections can be activated or there are no more elections to activate
 	void flush ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1772,7 +1772,7 @@ bool nano::node::populate_backlog ()
 		for (auto i = store.account.begin (transaction, next), n = store.account.end (); !stopped && i != n && count < chunk_size; ++i, ++count, ++total)
 		{
 			auto const & account = i->first;
-			overflow |= scheduler.activate (account, transaction);
+			overflow |= scheduler.activate (account, transaction, true);
 			next = account.number () + 1;
 		}
 		done = store.account.begin (transaction, next) == store.account.end ();


### PR DESCRIPTION
This PR tries to optimistically confirm account frontier when bootstrapping, instead of confirming each block one by one. From my testing it looks like this change speeds up confirmations during bootstrap more than 10x (on top of already merged improvements). 